### PR TITLE
Add instant and master deploy scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # ZEUS°NXTLVL GODMODE
 
 Full-stack autonomous trading system. Frontend (Next.js), backend (FastAPI), Docker, CI/CD ready.
+## Deployment Scripts
+- `deploy_instant.sh` quick local start
+- `deploy_master.sh` rebuild and launch Docker containers

--- a/deploy_instant.sh
+++ b/deploy_instant.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Instant deployment script
+
+# Quickly launch ZEUS without Docker
+
+echo "[+] Instant deploy starting..."
+python3 main.py --live
+echo "[+] Instant deploy finished."

--- a/deploy_master.sh
+++ b/deploy_master.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Master deployment script
+
+# Rebuild and launch Docker containers
+
+echo "[+] Rebuilding containers..."
+docker-compose down
+docker-compose up -d --build
+echo "[+] Master deploy complete."


### PR DESCRIPTION
## Summary
- add `deploy_instant.sh` for quick local runs
- add `deploy_master.sh` for rebuilding Docker containers
- document both scripts in the README

## Testing
- `python3 -m py_compile main.py zeus_trade_engine.py zeus_quantum_boost.py rsi_divergence_sniper.py momentum_killswitch.py risk_sentinel.py integrations.py strategy_router.py agent_db.py auth_guard.py paypal_off.py stripe_off.py nxtlvl.py wallet_sync.py mutation_engine.py performance_monitor.py`
- `bash -n deploy_instant.sh deploy_master.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854f41deebc8323a19635feb84fd081