### PR TITLE
Fix breakout calculation when price history small

### DIFF
--- a/zeus_quantum_boost.py
+++ b/zeus_quantum_boost.py
@@ -6,7 +6,17 @@ class QuantumBoost:
         self.sensitivity = sensitivity
 
     def detect_breakout(self, price_data, orderbook_data):
+        """Detect a breakout using recent price and order book information."""
+
+        # np.gradient requires at least two price points; otherwise a breakout
+        # cannot be determined reliably. In such cases we return False rather
+        # than raising an exception.
+        if len(price_data) < 2:
+            return False
+
         price_velocity = np.gradient(price_data)[-1]
-        volume_ratio = orderbook_data['bid_volume'] / (orderbook_data['ask_volume'] + 1e-8)
+        volume_ratio = orderbook_data['bid_volume'] / (
+            orderbook_data['ask_volume'] + 1e-8
+        )
         signal = price_velocity * volume_ratio
         return signal > self.sensitivity


### PR DESCRIPTION
## Summary
- prevent errors when QuantumBoost runs on less than two price points

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6854f394d88c832380e7ca21454920b8