### PR TITLE
Add dotenv config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # ZEUS°NXTLVL GODMODE
 
 Full-stack autonomous trading system. Frontend (Next.js), backend (FastAPI), Docker, CI/CD ready.
+
+The backend automatically loads environment variables from a `.env` file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 redis
+python-dotenv

--- a/zeus-nxtlvl/backend/core/config.py
+++ b/zeus-nxtlvl/backend/core/config.py
@@ -1,0 +1,9 @@
+from dotenv import load_dotenv
+import os
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+# Example configuration values
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///db.sqlite3")
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")


### PR DESCRIPTION
## Summary
- create `zeus-nxtlvl/backend/core/config.py` and load `.env` values on import
- document automatic `.env` loading in README
- add `python-dotenv` to backend requirements

## Testing
- `python -m py_compile *.py zeus-nxtlvl/backend/core/config.py`

------
https://chatgpt.com/codex/tasks/task_e_685e4e22bf408323858f847cf7234ca4