### PR TITLE
Add MultiAgentExecutor with cleanup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,21 +1,9 @@
+from multi_agent_executor import MultiAgentExecutor
 
-from zeus_trade_engine import ZeusTradeEngine
-import time
-import numpy as np
 
-engine = ZeusTradeEngine()
-
-price_data = []
-orderbook_data = {'bid_volume': 0, 'ask_volume': 0}
-
-def fetch_data():
-    return [100 + np.random.randn()], {'bid_volume': 500, 'ask_volume': 480}
-
-while True:
-    price, ob = fetch_data()
-    price_data.extend(price)
-    orderbook_data.update(ob)
-
-    decision = engine.run(price_data, orderbook_data)
-    print(f"[ZEUS] Decision: {decision}")
-    time.sleep(1)
+if __name__ == "__main__":
+    executor = MultiAgentExecutor()
+    try:
+        executor.run()
+    finally:
+        executor.close()

--- a/multi_agent_executor.py
+++ b/multi_agent_executor.py
@@ -1,0 +1,37 @@
+import sqlite3
+import time
+import numpy as np
+from zeus_trade_engine import ZeusTradeEngine
+
+
+class MultiAgentExecutor:
+    """Simple executor managing trading engine interactions."""
+
+    def __init__(self):
+        self.engine = ZeusTradeEngine()
+        # In lieu of a real message bus, use an in-memory SQLite DB
+        self.conn = sqlite3.connect(":memory:")
+
+    def fetch_data(self):
+        """Mock price and order book data."""
+        return [100 + np.random.randn()], {"bid_volume": 500, "ask_volume": 480}
+
+    def run(self, iterations=10):
+        """Run a loop of trading decisions."""
+        price_data = []
+        orderbook_data = {"bid_volume": 0, "ask_volume": 0}
+        for _ in range(iterations):
+            price, ob = self.fetch_data()
+            price_data.extend(price)
+            orderbook_data.update(ob)
+            if len(price_data) < 2:
+                continue
+            decision = self.engine.run(price_data, orderbook_data)
+            print(f"[ZEUS] Decision: {decision}")
+            time.sleep(1)
+
+    def close(self):
+        """Close internal resources."""
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None

--- a/rsi_divergence_sniper.py
+++ b/rsi_divergence_sniper.py
@@ -1,13 +1,33 @@
 
-import talib
 import numpy as np
 
 class RSIDivergenceSniper:
     def __init__(self, rsi_period=14):
         self.rsi_period = rsi_period
 
+    def _rsi(self, prices: np.ndarray) -> np.ndarray:
+        deltas = np.diff(prices)
+        seed = deltas[: self.rsi_period]
+        up = seed[seed >= 0].sum() / self.rsi_period
+        down = -seed[seed < 0].sum() / self.rsi_period
+        rs = up / down if down != 0 else 0
+        rsi = np.zeros_like(prices)
+        rsi[: self.rsi_period] = 100 - 100 / (1 + rs)
+        for i in range(self.rsi_period, len(prices)):
+            delta = deltas[i - 1]
+            upval = max(delta, 0)
+            downval = -min(delta, 0)
+            up = (up * (self.rsi_period - 1) + upval) / self.rsi_period
+            down = (down * (self.rsi_period - 1) + downval) / self.rsi_period
+            rs = up / down if down != 0 else 0
+            rsi[i] = 100 - 100 / (1 + rs)
+        return rsi
+
     def detect_entry(self, prices):
-        rsi = talib.RSI(np.array(prices), timeperiod=self.rsi_period)
+        prices = np.array(prices)
+        if len(prices) < self.rsi_period + 1:
+            return None
+        rsi = self._rsi(prices)
         oversold = rsi[-1] < 30
         overbought = rsi[-1] > 70
         return "long" if oversold else "short" if overbought else None


### PR DESCRIPTION
## Summary
- implement a `MultiAgentExecutor` class with a `close()` method
- rework `main.py` to use `MultiAgentExecutor`
- replace talib dependency in `RSIDivergenceSniper` with a pure numpy RSI implementation

## Testing
- `python -m py_compile multi_agent_executor.py main.py zeus_trade_engine.py momentum_killswitch.py rsi_divergence_sniper.py risk_sentinel.py zeus_quantum_boost.py`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_685e4e11920083239c6bda31143abbb8