### PR TITLE
Add tests for trade engine and breakout edge cases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 redis
+pytest

--- a/tests/test_trade_engine.py
+++ b/tests/test_trade_engine.py
@@ -1,0 +1,45 @@
+import types
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pytest
+if "talib" not in sys.modules:
+    talib_stub = types.ModuleType("talib")
+    def RSI(arr, timeperiod=14):
+        import numpy as np
+        return np.array([50]*len(arr))
+    talib_stub.RSI = RSI
+    sys.modules["talib"] = talib_stub
+
+
+from zeus_trade_engine import ZeusTradeEngine
+from zeus_quantum_boost import QuantumBoost
+
+
+def test_run_hold(monkeypatch):
+    engine = ZeusTradeEngine()
+
+    monkeypatch.setattr(engine.qb, "detect_breakout", lambda price, order: False)
+    monkeypatch.setattr(engine.rsi, "detect_entry", lambda price: None)
+    monkeypatch.setattr(engine.momentum, "should_exit", lambda price: False)
+    monkeypatch.setattr(engine.risk, "detect_vol_spike", lambda price: False)
+
+    result = engine.run([1, 2, 3], {"bid_volume": 100, "ask_volume": 100})
+    assert result == "HOLD"
+
+
+def test_run_execute_long(monkeypatch):
+    engine = ZeusTradeEngine()
+
+    monkeypatch.setattr(engine.qb, "detect_breakout", lambda price, order: True)
+    monkeypatch.setattr(engine.rsi, "detect_entry", lambda price: "long")
+    monkeypatch.setattr(engine.momentum, "should_exit", lambda price: False)
+    monkeypatch.setattr(engine.risk, "detect_vol_spike", lambda price: False)
+
+    result = engine.run([1, 2, 3, 4], {"bid_volume": 200, "ask_volume": 50})
+    assert result == "EXECUTE_LONG"
+
+
+def test_quantumboost_insufficient_data():
+    qb = QuantumBoost()
+    result = qb.detect_breakout([100], {"bid_volume": 10, "ask_volume": 5})
+    assert result is False

--- a/zeus_quantum_boost.py
+++ b/zeus_quantum_boost.py
@@ -6,6 +6,9 @@ class QuantumBoost:
         self.sensitivity = sensitivity
 
     def detect_breakout(self, price_data, orderbook_data):
+        if len(price_data) < 2:
+            return False
+
         price_velocity = np.gradient(price_data)[-1]
         volume_ratio = orderbook_data['bid_volume'] / (orderbook_data['ask_volume'] + 1e-8)
         signal = price_velocity * volume_ratio


### PR DESCRIPTION
## Summary
- add pytest to requirements
- handle short price history in `detect_breakout`
- test trade engine actions HOLD and EXECUTE_LONG
- test breakout detection with insufficient price data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f9f203ec832397cf4a0baf0fdada