### PR TITLE
Add unit tests for ZeusTradeEngine and QuantumBoost

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn[standard]
 redis
+pytest
+

--- a/tests/test_trade_engine.py
+++ b/tests/test_trade_engine.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import types
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal talib implementation for tests
+talib_mock = types.SimpleNamespace(RSI=lambda arr, timeperiod=14: np.zeros(len(arr)))
+sys.modules.setdefault("talib", talib_mock)
+
+from zeus_trade_engine import ZeusTradeEngine
+from zeus_quantum_boost import QuantumBoost
+
+
+def test_trade_engine_hold(monkeypatch):
+    engine = ZeusTradeEngine()
+    monkeypatch.setattr(engine.risk, "detect_vol_spike", lambda data: False)
+    monkeypatch.setattr(engine.qb, "detect_breakout", lambda prices, ob: False)
+
+    result = engine.run([100, 101], {"bid_volume": 1, "ask_volume": 1})
+    assert result == "HOLD"
+
+
+def test_trade_engine_execute_long(monkeypatch):
+    engine = ZeusTradeEngine()
+    monkeypatch.setattr(engine.risk, "detect_vol_spike", lambda data: False)
+    monkeypatch.setattr(engine.qb, "detect_breakout", lambda prices, ob: True)
+    monkeypatch.setattr(engine.rsi, "detect_entry", lambda prices: "long")
+    monkeypatch.setattr(engine.momentum, "should_exit", lambda prices: False)
+
+    result = engine.run([100, 102], {"bid_volume": 2, "ask_volume": 1})
+    assert result == "EXECUTE_LONG"
+
+
+def test_quantumboost_insufficient_price_data():
+    qb = QuantumBoost()
+    result = qb.detect_breakout([100], {"bid_volume": 1, "ask_volume": 1})
+    assert result is False

--- a/zeus_quantum_boost.py
+++ b/zeus_quantum_boost.py
@@ -6,6 +6,8 @@ class QuantumBoost:
         self.sensitivity = sensitivity
 
     def detect_breakout(self, price_data, orderbook_data):
+        if len(price_data) < 2:
+            return False
         price_velocity = np.gradient(price_data)[-1]
         volume_ratio = orderbook_data['bid_volume'] / (orderbook_data['ask_volume'] + 1e-8)
         signal = price_velocity * volume_ratio


### PR DESCRIPTION
## Summary
- add QuantumBoost edge case check for short price arrays
- create tests validating ZeusTradeEngine decisions
- simulate minimal talib for tests
- add pytest to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f9ed38088323ac86914b59ee1f45