### PR TITLE
Add unit tests for ZeusTradeEngine and QuantumBoost

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn[standard]
 redis
+numpy
+pytest

--- a/tests/test_trade_engine.py
+++ b/tests/test_trade_engine.py
@@ -1,0 +1,50 @@
+import sys
+import os
+import types
+import numpy as np
+import pytest
+
+# Create a minimal talib stub so zeus modules import correctly
+stub_talib = types.ModuleType('talib')
+
+def _rsi(prices, timeperiod=14):
+    # Return neutral RSI values to avoid triggering overbought/oversold
+    return np.array([50] * len(prices))
+
+stub_talib.RSI = _rsi
+sys.modules.setdefault('talib', stub_talib)
+
+# Ensure project root is on path for test discovery
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from zeus_trade_engine import ZeusTradeEngine
+from zeus_quantum_boost import QuantumBoost
+
+
+def test_trade_engine_hold(monkeypatch):
+    engine = ZeusTradeEngine()
+
+    # Force breakout detection to be false
+    monkeypatch.setattr(engine.qb, 'detect_breakout', lambda *args, **kwargs: False)
+    monkeypatch.setattr(engine.risk, 'detect_vol_spike', lambda *args, **kwargs: False)
+
+    result = engine.run([1, 1.02], {'bid_volume': 1, 'ask_volume': 1})
+    assert result == 'HOLD'
+
+
+def test_trade_engine_execute_long(monkeypatch):
+    engine = ZeusTradeEngine()
+
+    monkeypatch.setattr(engine.risk, 'detect_vol_spike', lambda *args, **kwargs: False)
+    monkeypatch.setattr(engine.qb, 'detect_breakout', lambda *args, **kwargs: True)
+    monkeypatch.setattr(engine.rsi, 'detect_entry', lambda *args, **kwargs: 'long')
+    monkeypatch.setattr(engine.momentum, 'should_exit', lambda *args, **kwargs: False)
+
+    result = engine.run([1, 1.1], {'bid_volume': 2, 'ask_volume': 1})
+    assert result == 'EXECUTE_LONG'
+
+
+def test_quantumboost_insufficient_data():
+    qb = QuantumBoost()
+    result = qb.detect_breakout([100], {'bid_volume': 1, 'ask_volume': 1})
+    assert result is False

--- a/zeus_quantum_boost.py
+++ b/zeus_quantum_boost.py
@@ -6,7 +6,13 @@ class QuantumBoost:
         self.sensitivity = sensitivity
 
     def detect_breakout(self, price_data, orderbook_data):
+        """Return True if price momentum and volume indicate a breakout."""
+        if len(price_data) < 2:
+            return False
+
         price_velocity = np.gradient(price_data)[-1]
-        volume_ratio = orderbook_data['bid_volume'] / (orderbook_data['ask_volume'] + 1e-8)
+        volume_ratio = orderbook_data['bid_volume'] / (
+            orderbook_data['ask_volume'] + 1e-8
+        )
         signal = price_velocity * volume_ratio
         return signal > self.sensitivity


### PR DESCRIPTION
## Summary
- expand requirements with numpy and pytest
- handle insufficient price data in `QuantumBoost.detect_breakout`
- add test suite for ZeusTradeEngine and breakout detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f82e1d988323a872723a981be660