### PR TITLE
Add numeric libs to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-fastapi
-uvicorn[standard]
-redis
+fastapi==0.115.14
+uvicorn[standard]==0.34.3
+redis==6.2.0
+numpy==1.26.4
+pandas==2.3.0
+TA-Lib==0.6.4


### PR DESCRIPTION
## Summary
- pin package versions for repeatable installs
- add numpy, pandas and TA-Lib

## Testing
- `pytest tests/agents/` *(fails: file or directory not found)*
- `python backtest_engine.py --agent DummyAgent` *(fails: file not found)*
- `ruff check agents/` *(fails: no such file or directory)*
- `black agents/` *(fails: path does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685eb72ec7c08323b3ec7fa04c830596