### PR TITLE
[agents/RSIDivergenceSniper] Add tests and remove talib dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ This repository contains a minimal prototype of the ZEUS°NXTLVL autonomous trad
 - Nightly capital boost logic for rapid compounding
 - Example trade engine wiring agents together
 
+## Running Tests
+
+Install dependencies and execute the test suite with `pytest`:
+
+```bash
+pip install -r requirements.txt numpy pandas
+pytest -v
+```
+

--- a/risk_sentinel.py
+++ b/risk_sentinel.py
@@ -1,6 +1,3 @@
-
-import numpy as np
-
 class RiskSentinel:
     def __init__(self, threshold=0.05):
         self.threshold = threshold

--- a/rsi_divergence_sniper.py
+++ b/rsi_divergence_sniper.py
@@ -1,16 +1,40 @@
-
-import talib
 import numpy as np
 
+
+def _compute_rsi(prices: np.ndarray, period: int) -> np.ndarray:
+    """Simple RSI implementation to avoid external TA-Lib dependency."""
+    prices = np.asarray(prices, dtype=float)
+    if len(prices) <= period:
+        return np.array([])
+    deltas = np.diff(prices)
+    seed = deltas[:period]
+    up = seed[seed > 0].sum() / period
+    down = -seed[seed < 0].sum() / period
+    rs = up / down if down != 0 else float("inf")
+    rsi_values = [100 - 100 / (1 + rs)]
+    up_avg = up
+    down_avg = down
+    for delta in deltas[period:]:
+        up_val = max(delta, 0)
+        down_val = max(-delta, 0)
+        up_avg = (up_avg * (period - 1) + up_val) / period
+        down_avg = (down_avg * (period - 1) + down_val) / period
+        rs = up_avg / down_avg if down_avg != 0 else float("inf")
+        rsi_values.append(100 - 100 / (1 + rs))
+    return np.array(rsi_values)
+
+
 class RSIDivergenceSniper:
-    def __init__(self, rsi_period=14):
+    def __init__(self, rsi_period: int = 14):
         self.rsi_period = rsi_period
 
-    def detect_entry(self, prices):
+    def detect_entry(self, prices) -> str | None:
         """Determine long/short entry based on RSI divergence."""
-        if len(prices) < self.rsi_period:
+        if len(prices) < self.rsi_period + 1:
             return None
-        rsi = talib.RSI(np.array(prices), timeperiod=self.rsi_period)
+        rsi = _compute_rsi(np.array(prices), self.rsi_period)
+        if rsi.size == 0:
+            return None
         oversold = rsi[-1] < 30
         overbought = rsi[-1] > 70
         return "long" if oversold else "short" if overbought else None

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,65 @@
+import pytest
+
+from rsi_divergence_sniper import RSIDivergenceSniper
+from momentum_killswitch import MomentumKillSwitch
+from risk_sentinel import RiskSentinel
+from zeus_trade_engine import ZeusTradeEngine
+
+
+@pytest.fixture
+def bullish_prices():
+    return list(range(20))
+
+
+@pytest.fixture
+def bearish_prices():
+    return list(range(20, 0, -1))
+
+
+def test_rsi_divergence_sniper_long(bearish_prices):
+    sniper = RSIDivergenceSniper(rsi_period=14)
+    assert sniper.detect_entry(bearish_prices) == "long"
+
+
+def test_rsi_divergence_sniper_short(bullish_prices):
+    sniper = RSIDivergenceSniper(rsi_period=14)
+    assert sniper.detect_entry(bullish_prices) == "short"
+
+
+def test_momentum_killswitch():
+    mk = MomentumKillSwitch(window=3)
+    assert mk.should_exit([4, 3, 2, 1])
+    assert not mk.should_exit([1, 2, 3, 4])
+
+
+def test_risk_sentinel():
+    sentinel = RiskSentinel(threshold=0.05)
+    assert sentinel.detect_vol_spike([100, 106]) is True
+    assert sentinel.detect_vol_spike([100, 102]) is False
+
+
+def test_engine_run_executes(monkeypatch):
+    engine = ZeusTradeEngine()
+    engine.qb = type("QB", (), {"detect_breakout": lambda self, p, o: True})()
+    engine.rsi = type("RSI", (), {"detect_entry": lambda self, p: "long"})()
+    engine.momentum = type("MK", (), {"should_exit": lambda self, p: False})()
+    engine.risk = type("Risk", (), {"detect_vol_spike": lambda self, p: False})()
+    res = engine.run([1, 2], {"bid_volume": 2, "ask_volume": 1})
+    assert res == "EXECUTE_LONG"
+
+
+def test_engine_run_halt(monkeypatch):
+    engine = ZeusTradeEngine()
+    engine.risk = type("Risk", (), {"detect_vol_spike": lambda self, p: True})()
+    res = engine.run([1, 2], {"bid_volume": 2, "ask_volume": 1})
+    assert res == "HALT"
+
+
+def test_engine_run_hold(monkeypatch):
+    engine = ZeusTradeEngine()
+    engine.qb = type("QB", (), {"detect_breakout": lambda self, p, o: True})()
+    engine.rsi = type("RSI", (), {"detect_entry": lambda self, p: None})()
+    engine.momentum = type("MK", (), {"should_exit": lambda self, p: False})()
+    engine.risk = type("Risk", (), {"detect_vol_spike": lambda self, p: False})()
+    res = engine.run([1, 2], {"bid_volume": 2, "ask_volume": 1})
+    assert res == "HOLD"


### PR DESCRIPTION
## Summary
- simplify `RSIDivergenceSniper` by replacing TA‑Lib with local RSI calc
- add unit tests covering ZeusTradeEngine and supporting utilities
- document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb73d95e88323aaf698f22b3f76f5